### PR TITLE
Added the AllowClobber parameter to the PSModule resource

### DIFF
--- a/DSCResources/MSFT_PSModule/MSFT_PSModule.schema.mfl
+++ b/DSCResources/MSFT_PSModule/MSFT_PSModule.schema.mfl
@@ -12,6 +12,7 @@ class MSFT_PSModule : OMI_BaseResource
   [Description("The required version of the module.\n") : Amended] String RequiredVersion;
   [Description("The minimum version of the module.\n") : Amended] String MinimumVersion;
   [Description("The maximum version of the module.\n") : Amended] String MaximumVersion;
+  [Description("Allow installation of the module when duplicate commands exist from a previously installed Module.\n") : Amended] Boolean AllowClobber;
   [Description("The brief description of the module.\n") : Amended] string Description;
   [Description("The version of the module that is installed.\n") : Amended] String InstalledVersion;
   [Description("The identifier of the module.\n") : Amended] String Guid;

--- a/DSCResources/MSFT_PSModule/MSFT_PSModule.schema.mof
+++ b/DSCResources/MSFT_PSModule/MSFT_PSModule.schema.mof
@@ -9,6 +9,7 @@ class MSFT_PSModule : OMI_BaseResource
   [Write] String RequiredVersion;
   [Write] String MaximumVersion;
   [Write] String MinimumVersion;
+  [Write] Boolean AllowClobber;
   [Read] string Description;
   [Read] String InstalledVersion;
   [Read] String Guid;

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
     <td>Specifies the minimum version of the module you want to install or uninstall.</td>
     </tr>
     <tr>
+    <td>AllowClobber</td>
+    <td>Allow installation of the module when duplicate commands exist from a previously installed Module.</td>
+    </tr>
+    <tr>
     <td>Repository</td>
     <td>Specifies the name of the module source repository where the module can found.</td>
     </tr>


### PR DESCRIPTION
This adds the ability to specify the AllowClobber parameter.

The change was made on the Set function.

Used Splatting to add this extra optional 'AllowClobber' parameter on the Install-Module Cmdlet.

There was only as single named parameter before for ErrorVariable, so I created the hashtable that includes that value with the optional AllowClobber.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/packagemanagementproviderresource/39)
<!-- Reviewable:end -->
