### PR TITLE
adding support for install-module switches

### DIFF
--- a/DSCResources/MSFT_PSModule/MSFT_PSModule.schema.mof
+++ b/DSCResources/MSFT_PSModule/MSFT_PSModule.schema.mof
@@ -9,6 +9,9 @@ class MSFT_PSModule : OMI_BaseResource
   [Write] String RequiredVersion;
   [Write] String MaximumVersion;
   [Write] String MinimumVersion;
+  [Write] Boolean Force;
+  [Write] Boolean AllowClobber;
+  [Write] Boolean SkipPublisherCheck;
   [Read] string Description;
   [Read] String InstalledVersion;
   [Read] String Guid;


### PR DESCRIPTION
This is a continuation of something i previously tried to fix but in the wrong repository. See https://github.com/OneGet/oneget/pull/337 where it was agreed that PackageManagement module should be kept generic. 

This is PR is to solve the issue raised here: https://github.com/OneGet/oneget/issues/327

At some point the options -Force, -AllowClobber & -SkipPublisherCheck were added to the PowerShellGet cmdlets. Here I am adding support for them in the DSC Resource.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/packagemanagementproviderresource/40)
<!-- Reviewable:end -->
